### PR TITLE
refactor: streamline imports in ColorPicker and public utilities

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -1,10 +1,7 @@
 import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 
-import type { ColorInput, ColorPickerProps, HsvaColor } from '../types';
-import { Color } from '../types';
-import { cn } from '../utils';
-
-import { convertColor } from '../utils';
+import { Color, type ColorInput, type ColorPickerProps, type HsvaColor } from '../types';
+import { cn, convertColor } from '../utils';
 import { Alpha } from './Alpha';
 import { Hue } from './Hue';
 import { Saturation } from './Saturation';

--- a/src/utils/public.ts
+++ b/src/utils/public.ts
@@ -1,5 +1,15 @@
-import type { ColorFormat, ColorInput, HexColor, HslaColor, HslColor, HsvaColor, HsvColor, RgbaColor, RgbColor } from '../types';
-import { Color } from '../types';
+import {
+  Color,
+  type ColorFormat,
+  type ColorInput,
+  type HexColor,
+  type HslaColor,
+  type HslColor,
+  type HsvaColor,
+  type HsvColor,
+  type RgbaColor,
+  type RgbColor,
+} from '../types';
 import { assertUnreachable } from './internal';
 
 const clamp = (num: number, min: number, max: number): number => Math.min(Math.max(num, min), max);


### PR DESCRIPTION
Some files imported from the same module twice, once with import type and again with a regular import. That was redundant and harder to read.
I merged those into a single import per module using inline type specifiers, for example importing Color as a value and ColorInput as a type from the same path. Two files were updated: ColorPicker.tsx and src/utils/public.ts. Behavior is unchanged; the imports are just cleaner.